### PR TITLE
Add #pragma warning directives

### DIFF
--- a/libs/amxxpc32/src/sc.h
+++ b/libs/amxxpc32/src/sc.h
@@ -667,6 +667,9 @@ SC_FUNC void outval(cell val, int newline);
 /* function prototypes in SC5.C */
 SC_FUNC int error(int number, ...) INVISIBLE;
 SC_FUNC void errorset(int code, int line);
+SC_FUNC void pushwarnings(void);
+SC_FUNC void popwarnings(void);
+SC_FUNC void clear_warningstack(void);
 
 /* function prototypes in SC6.C */
 SC_FUNC int assemble(FILE* fout, FILE* fin);

--- a/libs/amxxpc32/src/sc1.c
+++ b/libs/amxxpc32/src/sc1.c
@@ -842,6 +842,7 @@ cleanup:
 #endif
     delete_autolisttable();
     delete_heaplisttable();
+    clear_warningstack();
     if (errnum != 0) {
         if (strlen(errfname) == 0)
             pc_printf("\n%d Error%s.\n", errnum, (errnum > 1) ? "s" : "");

--- a/libs/amxxpc32/src/sc2.c
+++ b/libs/amxxpc32/src/sc2.c
@@ -1226,6 +1226,24 @@ static int command(void)
                         }
                         while (comma);
                     }
+                    else if (strcmp(str, "warning") == 0) {
+                        if ((lex(&val, &str) == tSYMBOL)) {
+                            if (strcmp(str, "push") == 0) {
+                                pushwarnings();
+                            }
+                            else if (strcmp(str, "pop") == 0) {
+                                popwarnings();
+                            }
+                            else if (strcmp(str, "enable") == 0) {
+                                preproc_expr(&val, NULL); /* get value (or 0 on error) */
+                                pc_enablewarning((int)val, 1);
+                            }
+                            else if (strcmp(str, "disable") == 0) {
+                                preproc_expr(&val, NULL); /* get value (or 0 on error) */
+                                pc_enablewarning((int)val, 0);
+                            }
+                        }
+                    }
                     else if (strcmp(str, "showstackusageinfo") == 0) {
                         sc_stkusageinfo = TRUE;
                     }

--- a/libs/amxxpc32/src/sc5-in.scp
+++ b/libs/amxxpc32/src/sc5-in.scp
@@ -107,7 +107,16 @@ static char* errmsg[] = {
     /*085*/ "no states are defined for function \"%s\"\n",
     /*086*/ "unknown automaton \"%s\"\n",
     /*087*/ "unknown state \"%s\" for automaton \"%s\"\n",
-    /*088*/ "number of arguments does not match definition\n"};
+    /*088*/ "number of arguments does not match definition\n",
+    /*089*/ "state variables may not be initialized (symbol \"%s\")",
+    /*090*/ "public functions may not return arrays (symbol \"%s\")",
+    /*091*/ "first constant in an enumerated list must be initialized (symbol \"%s\")",
+    /*092*/ "invalid number format",
+    /*093*/ "array fields with a size may only appear in the final dimension",
+    /*094*/ "invalid subscript, subscript does not match array definition regarding named indices (symbol \"%s\")",
+    /*095*/ "multiple default entry points: both main() and @start() are declared",
+    /*096*/ "\"#pragma warning push\" is lacking a matching \"pop\"",
+    /*097*/ "\"#pragma warning pop\" is lacking a matching \"push\""};
 
 static char* fatalmsg[] = {
     /*100*/ "cannot read from file: \"%s\"\n",


### PR DESCRIPTION
## Summary
Implementation of `#pragma warning` directives, enabling developers to control warning behavior during compilation with suppression and restoration mechanisms.

## Details
The following directives have been implemented to manage compiler warnings:

- `#pragma warning disable <value>`
Disables (hides) a warning specified by its numeric identifier.

- `#pragma warning enable <value>`
Enables a warning specified by its numeric identifier.
- `#pragma warning push`
Stores the enabled/disabled status of all warnings on an internal stack for later restoration.
- `#pragma warning pop`
Restores the enabled/disabled status of all warnings, which must have been previously pushed onto the stack.

## Examples
### Example 1: Suppressing a specific warning
```pawn
#pragma warning disable 203 // Suppress "symbol is never used" warning 
new unusedVar = 0           // No warning
```

### Example 2: push/pop warning state
```pawn
#pragma warning push
#pragma warning disable 209 // Suppress "function should return a value" warning
#pragma warning disable 217 // Suppress "loose indentation" warning

public function() {
    new variable;
          variable += 24;
          if (variable)
 return variable *= 3;
}

#pragma warning pop // Warnings 209 and 217 are enabled again
```
Expected behavior: Warnings 209 and 217 are not emitted in the `push`/`pop` block due to suppressed warnings.
After `#pragma warning pop`, warnings 209 and 217 are re-enabled for subsequent code.