### PR TITLE
fix: Initialize variables to prevent undefined behavior

### DIFF
--- a/apps/amxxpc/src/amx.cpp
+++ b/apps/amxxpc/src/amx.cpp
@@ -2719,7 +2719,7 @@ int AMXAPI amx_Exec(AMX* amx, cell* retval, int index)
         #else
     OPCODE op;
     cell offs;
-    int num;
+    int num = 0;
         #endif
         #if defined ASM32
     extern void const* amx_opcodelist[];

--- a/libs/amxxpc32/src/sc1.c
+++ b/libs/amxxpc32/src/sc1.c
@@ -2031,7 +2031,7 @@ static void declglb(
     int numdim;
     short filenum;
     symbol* sym;
-    constvalue* enumroot;
+    constvalue* enumroot = NULL;
 #if !defined NDEBUG
     cell glbdecl = 0;
 #endif
@@ -2165,7 +2165,7 @@ static int declloc(const int fstatic)
     int idxtag[sDIMEN_MAX];
     char name[sNAMEMAX + 1];
     symbol* sym;
-    constvalue* enumroot;
+    constvalue* enumroot = NULL;
     cell val, size;
     char* str;
     value lval = {0};
@@ -2892,7 +2892,7 @@ static void decl_enum(const int vclass)
     /* go through all constants */
     value = 0; /* default starting value */
     do {
-        int fieldtag;
+        int fieldtag = 0;
         if (matchtoken('}')) { /* quick exit if '}' follows ',' */
             lexpush();
             break;
@@ -2956,7 +2956,7 @@ static int getstates(const char* funcname)
     char fsaname[sNAMEMAX + 1], statename[sNAMEMAX + 1];
     cell val;
     char* str;
-    constvalue* automaton;
+    constvalue* automaton = NULL;
     int islabel;
     int* list;
     int count, listsize, state_id;

--- a/libs/amxxpc32/src/sc3.c
+++ b/libs/amxxpc32/src/sc3.c
@@ -1099,8 +1099,8 @@ static int hier13(value* lval)
     const int lvalue = plnge1(hier12, lval);
     if (matchtoken('?')) {
         const int locheap = decl_heap; /* save current heap delta */
-        long heap1, heap2;             /* max. heap delta either branch */
-        valuepair* heaplist_node;
+        long heap1 = 0, heap2 = 0;     /* max. heap delta either branch */
+        valuepair* heaplist_node = NULL;
         const int flab1 = getlabel();
         const int flab2 = getlabel();
         value lval2 = {0};
@@ -1863,6 +1863,7 @@ static int primary(value* lval)
     cell val;
     symbol* sym;
 
+    assert(lval != NULL);
     if (matchtoken('(')) { /* sub-expression - (expression,...) */
         PUSHSTK_I(sc_intest)
         PUSHSTK_I(sc_allowtags)
@@ -1908,7 +1909,7 @@ static int primary(value* lval)
             return TRUE; /* return 1 if lvalue (not label or array) */
         } /* if */
         /* now try a global variable */
-        if ((sym = findglb(st)) != 0) {
+        if ((sym = findglb(st)) != NULL) {
             if (sym->ident == iFUNCTN || sym->ident == iREFFUNC) {
                 /* if the function is only in the table because it was inserted as a
                  * stub in the first pass (i.e. it was "used" but never declared or
@@ -1939,7 +1940,6 @@ static int primary(value* lval)
             /* an unknown symbol, but used in a way compatible with the "procedure
              * call" syntax. So assume that the symbol refers to a function.
              */
-            assert(sc_status == statFIRST);
             sym = fetchfunc(st, 0);
             if (sym == NULL) {
                 error(103); /* insufficient memory */


### PR DESCRIPTION
Addressed potential undefined behavior caused by accessing uninitialized variables.
All affected variables and pointers are now initialized upon declaration.