### PR TITLE
fix(pc_writesrc): Ensure correct pointer reference after memory reallocation

### DIFF
--- a/libs/amxxpc32/src/libpawnc.c
+++ b/libs/amxxpc32/src/libpawnc.c
@@ -334,11 +334,13 @@ int pc_writesrc(void* handle, unsigned char* source)
             }
         }
 
+        // Store src->pos offset relative to src->buffer before reallocating
+        const ptrdiff_t pos_offset = src->pos - src->buffer;
         char* newbuf = realloc(src->buffer, newmax);
         if (!newbuf) {
             abort();
         }
-        src->pos = newbuf + (src->pos - src->buffer);
+        src->pos = newbuf + pos_offset;
         src->end = newbuf + newmax;
         src->buffer = newbuf;
         src->maxlength = newmax;


### PR DESCRIPTION
Corrected a pointer issue where an offset was calculated using a pointer that could have become invalid after a `realloc` call.