### PR TITLE
refactor: Link amxxpc32 library statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,10 +167,6 @@ include("cmake/ClangTidy.cmake")
 include("cmake/Cppcheck.cmake")
 include("cmake/PvsStudio.cmake")
 
-if(UNIX)
-  find_package(Threads REQUIRED)
-endif()
-
 #-------------------------------------------------------------------------------
 # Subdirectories
 #-------------------------------------------------------------------------------

--- a/apps/amxxpc/CMakeLists.txt
+++ b/apps/amxxpc/CMakeLists.txt
@@ -87,6 +87,10 @@ target_compile_definitions("${TARGET_NAME}"
     AMX_ANSIONLY
     HAVE_STDINT_H
 
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:
+      BUILD_STATIC_AMXXPC
+    >
+
     $<$<PLATFORM_ID:Windows>:
       _MBCS
       _CRT_SECURE_NO_WARNINGS

--- a/apps/amxxpc/src/amx.cpp
+++ b/apps/amxxpc/src/amx.cpp
@@ -35,11 +35,11 @@
 #endif
 
 #include "osdefs.h"
-#include <assert.h>
-#include <limits.h>
-#include <stdarg.h>
-#include <stddef.h> /* for wchar_t */
-#include <string.h>
+#include <cassert>
+#include <climits>
+#include <cstdarg>
+#include <cstddef> /* for wchar_t */
+#include <cstring>
 #if defined LINUX || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
     #include "sclinux.h"
     #if !defined AMX_NODYNALOAD

--- a/apps/amxxpc/src/amxdbg.h
+++ b/apps/amxxpc/src/amxdbg.h
@@ -25,6 +25,8 @@
 #ifndef AMXDBG_H_INCLUDED
 #define AMXDBG_H_INCLUDED
 
+#include <cstdio>
+
 #ifndef AMX_H_INCLUDED
     #include "amx.h"
 #endif

--- a/apps/amxxpc/src/amxxpc.cpp
+++ b/apps/amxxpc/src/amxxpc.cpp
@@ -7,8 +7,7 @@
 // Additional exceptions apply. For full license details, see LICENSE.txt or visit:
 //     https://alliedmods.net/amxmodx-license
 
-#include <stdio.h>
-#if defined(__linux__) | defined(__APPLE__)
+#if defined(__linux__) || defined(__APPLE__)
     #include <unistd.h>
 #else
     #include <fcntl.h>
@@ -19,7 +18,20 @@
 #include "amxxpc.h"
 #include "binary.h"
 #include "zlib.h"
-#include <stdlib.h>
+#include <cstdio>
+#include <cstdlib>
+
+#ifdef BUILD_STATIC_AMXXPC
+    #include <sc.h>
+extern "C" void Compile32(int argc, char** argv);
+#else
+    #if defined(EMSCRIPTEN)
+extern "C" void Compile32(int argc, char** argv);
+extern "C" int pc_printf(const char* message, ...);
+    #else
+static PRINTF pc_printf = nullptr;
+    #endif
+#endif
 
 #ifdef _MSC_VER
     // MSVC8 - replace POSIX functions with ISO C++ conformant ones as they are deprecated
@@ -33,21 +45,15 @@ bool CompressPl(abl* pl);
 void Pl2Bh(const abl* pl, BinPlugin* bh);
 void WriteBh(const BinaryWriter* bw, const BinPlugin* bh);
 
-#if defined(EMSCRIPTEN)
-extern "C" void Compile32(int argc, char** argv);
-extern "C" int pc_printf(const char* message, ...);
-#else
-static PRINTF pc_printf = nullptr;
-#endif
-
 int main(const int argc, char** argv)
 {
     abl pl32;
 
-#if defined(EMSCRIPTEN)
+#ifndef BUILD_STATIC_AMXXPC
+    #if defined(EMSCRIPTEN)
     COMPILER sc32 = (COMPILER)Compile32;
-#else
-    #if defined(__linux__)
+    #else
+        #if defined(__linux__)
     HINSTANCE lib = NULL;
     if (FileExists("./amxxpc32.so")) {
         lib = dlmount("./amxxpc32.so");
@@ -55,32 +61,35 @@ int main(const int argc, char** argv)
     else {
         lib = dlmount("amxxpc32.so");
     }
-    #elif defined(__APPLE__)
+        #elif defined(__APPLE__)
     HINSTANCE lib = dlmount("amxxpc32.dylib");
-    #else
+        #else
     const HINSTANCE lib = dlmount("amxxpc32.dll");
-    #endif
+        #endif
     if (!lib) {
-    #if defined(__linux__) || defined(__APPLE__)
+        #if defined(__linux__) || defined(__APPLE__)
         printf("compiler failed to instantiate: %s\n", dlerror());
-    #else
+        #else
         printf("compiler failed to instantiate: %d\n", GetLastError());
-    #endif
+        #endif
         exit(EXIT_FAILURE);
     }
 
     const auto sc32 = (COMPILER)dlsym(lib, "Compile32");
     pc_printf = (PRINTF)dlsym(lib, "pc_printf");
-#endif // EMSCRIPTEN
+    #endif // EMSCRIPTEN
 
     if (!sc32 || !pc_printf) {
-#if defined(__linux__) || defined(__APPLE__)
+    #if defined(__linux__) || defined(__APPLE__)
         printf("compiler failed to link: %p.\n", sc32);
-#else
+    #else
         printf("compiler failed to link: %d.\n", GetLastError());
-#endif
+    #endif
         exit(EXIT_FAILURE);
     }
+#else
+    const auto sc32 = (COMPILER)Compile32;
+#endif
 
     pc_printf("AMX Mod X Compiler %s\n\n", AMXX_VERSION);
     pc_printf("Copyright (c) 1997-2006 ITB CompuPhase\n");
@@ -175,7 +184,7 @@ int main(const int argc, char** argv)
         fclose(fp);
         unlink(file);
         pc_printf("Error, failed to write binary\n");
-#if !defined EMSCRIPTEN
+#if !defined(BUILD_STATIC_AMXXPC) && !defined(EMSCRIPTEN)
         dlclose(lib);
 #endif
         exit(EXIT_FAILURE);
@@ -190,7 +199,7 @@ int main(const int argc, char** argv)
     and "Compile and upload" buttons in AMXX-Studio doesn't work.
     */
     pc_printf("Done.\n");
-#if !defined EMSCRIPTEN
+#if !defined(BUILD_STATIC_AMXXPC) && !defined(EMSCRIPTEN)
     dlclose(lib);
 #endif
 

--- a/apps/amxxpc/src/sclinux.h
+++ b/apps/amxxpc/src/sclinux.h
@@ -34,7 +34,7 @@
     #if defined EMSCRIPTEN
         #include <endian.h>
     #else
-        #include <stdlib.h>
+        #include <cstdlib>
     #endif
     #if defined __APPLE__
         #include <sys/types.h>

--- a/libs/amxxpc32/CMakeLists.txt
+++ b/libs/amxxpc32/CMakeLists.txt
@@ -11,7 +11,7 @@ project("AMXX Nova Pawn Compiler Lib" LANGUAGES "C")
 set(TARGET_NAME "amxxpc32")
 set(TARGET_ALIAS "PCLib::${TARGET_NAME}")
 
-add_library("${TARGET_NAME}" SHARED)
+add_library("${TARGET_NAME}")
 add_library("${TARGET_ALIAS}" ALIAS "${TARGET_NAME}")
 
 #-------------------------------------------------------------------------------
@@ -65,9 +65,12 @@ set_target_properties("${TARGET_NAME}"
 target_compile_definitions("${TARGET_NAME}"
   PRIVATE
     NO_MAIN
-    PAWNC_DLL
     HAVE_STDINT_H
     PAWN_CELL_SIZE=32
+
+    $<$<BOOL:${BUILD_SHARED_LIBS}>:
+      PAWNC_DLL
+    >
 
     $<$<PLATFORM_ID:Windows>:
       _MBCS
@@ -78,18 +81,5 @@ target_compile_definitions("${TARGET_NAME}"
     $<$<NOT:$<PLATFORM_ID:Windows>>:
       LINUX
       ENABLE_BINRELOC
-    >
-)
-
-#-------------------------------------------------------------------------------
-# Link Libraries
-#-------------------------------------------------------------------------------
-
-target_link_libraries("${TARGET_NAME}"
-  PRIVATE
-    $<$<NOT:$<PLATFORM_ID:Windows>>:
-      "c"
-      "m"
-      "Threads::Threads"
     >
 )

--- a/libs/amxxpc32/src/libpawnc.c
+++ b/libs/amxxpc32/src/libpawnc.c
@@ -29,51 +29,46 @@
 #include <string.h>
 
 #if defined PAWNC_DLL
+    #if defined _MSC_VER
+        #define AMXXPC_API __declspec(dllexport)
+    #else
+        #define AMXXPC_API __attribute__((visibility("default")))
+    #endif
 
     #if !defined(__linux__) && !defined(__APPLE__)
         #include "dllmain.c"
     #endif
+#else
+    #define AMXXPC_API
+#endif
 
-    #define MAX_ARGS 100
-    #if !defined UNUSED_PARAM
-        #define UNUSED_PARAM(p) ((void)(p))
-    #endif
-
-    #if PAWN_CELL_SIZE == 32
-        #define EXCOMPILER Compile32
-    #else
-        #define EXCOMPILER Compile64
-    #endif
-
-    #if defined __WIN32__ || defined _WIN32 || defined WIN32 || defined __NT__
-__declspec(dllexport) void EXCOMPILER(const int argc, char** argv)
-    #else
-void extern __attribute__((visibility("default"))) EXCOMPILER(const int argc, char** argv)
-    #endif
-{
-    pc_compile(argc, argv);
-}
-#endif /* PAWNC_DLL */
+#define MAX_ARGS 100
+#if !defined UNUSED_PARAM
+    #define UNUSED_PARAM(p) ((void)(p))
+#endif
 
 #if defined LINUX || defined __FreeBSD__ || defined __OpenBSD__ || defined __APPLE__
     #include <sys/stat.h>
     #include <sys/types.h>
 #endif
 
+#if PAWN_CELL_SIZE == 32
+    #define EXCOMPILER Compile32
+#else
+    #define EXCOMPILER Compile64
+#endif
+
+AMXXPC_API void EXCOMPILER(const int argc, char** argv)
+{
+    pc_compile(argc, argv);
+}
+
 /* pc_printf()
  * Called for general purpose "console" output. This function prints general
  * purpose messages; errors go through pc_error(). The function is modelled
  * after printf().
  */
-#if PAWN_CELL_SIZE == 32
-    #if defined __WIN32__ || defined _WIN32 || defined WIN32
-__declspec(dllexport) int pc_printf(const char* message, ...)
-    #else
-extern int __attribute__((visibility("default"))) pc_printf(const char* message, ...)
-    #endif
-#else
-int pc_printf(const char* message, ...)
-#endif
+AMXXPC_API int pc_printf(const char* message, ...)
 {
 #if PAWN_CELL_SIZE == 32
     va_list argptr;


### PR DESCRIPTION
# Summary
Build the `amxxpc32` library as a static library instead of a dynamic/shared library (`.dll`/`.so`).
The goal is to simplify distribution by creating a single, self-contained `amxxpc` executable that does not depend on external library files.

# Motivation
- **Simpler Distribution:** No need to ship a separate `.dll` or `.so` file alongside the
executable.
- **Improved Robustness:** Eliminates runtime errors caused by a missing or incorrect version of
the library file.