### PR TITLE
feat: Enhance command-line definitions for constants and macros

### DIFF
--- a/apps/amxxpc/src/amxxpc.cpp
+++ b/apps/amxxpc/src/amxxpc.cpp
@@ -317,9 +317,8 @@ char* swiext(const char* file, const char* ext, const int isO)
 
 char* FindFileName(const int argc, char** argv)
 {
-    int i = 0;
     int save = -1;
-    for (i = 1; i < argc; i++) {
+    for (int i = 1; i < argc; i++) {
         if (argv[i][0] == '-' && argv[i][1] == 'o') {
             if (argv[i][2] == ' ' || argv[i][2] == '\0') {
                 if (i == argc - 1) {
@@ -361,6 +360,8 @@ void show_help()
     printf("\t-p<name>  set name of \"prefix\" file\n");
     printf("\t-r[name]  write cross reference report to console or to specified file\n");
     printf("\t-sui[+/-] show stack usage info\n");
+    printf("\tsym=val   define constant \"sym\" with value \"val\"\n");
+    printf("\tsym=      define constant \"sym\" with value 1\n");
 }
 
 #if defined(__linux__) || defined(__APPLE__)

--- a/libs/amxxpc32/src/sc1.c
+++ b/libs/amxxpc32/src/sc1.c
@@ -145,8 +145,55 @@ static char* sc_documentation = NULL; /* main documentation */
 static HWND hwndFinish = 0;
 #endif
 
-#if !defined NO_MAIN
+typedef struct s_cli_define {
+    char* name;
+    char* value;
+    struct s_cli_define* next;
+} cli_define;
 
+static cli_define* cli_defines_list = NULL;
+
+static void add_cli_define(const char* name, const char* value)
+{
+    cli_define* def = malloc(sizeof(cli_define));
+    if (def == NULL) {
+        error(103); /* insufficient memory */
+    }
+    def->name = strdup(name);
+    if (def->name == NULL) {
+        error(103);
+    }
+    def->value = strdup(value);
+    if (def->value == NULL) {
+        error(103);
+    }
+    def->next = cli_defines_list;
+    cli_defines_list = def;
+}
+
+static void delete_cli_defines(void)
+{
+    cli_define* def = cli_defines_list;
+    while (def != NULL) {
+        cli_define* next = def->next;
+        free(def->name);
+        free(def->value);
+        free(def);
+        def = next;
+    }
+    cli_defines_list = NULL;
+}
+
+static void inst_cli_defines(void)
+{
+    const cli_define* def = cli_defines_list;
+    while (def != NULL) {
+        insert_subst(def->name, def->value, (int)strlen(def->name));
+        def = def->next;
+    }
+}
+
+#if !defined NO_MAIN
     #if defined __TURBOC__ && !defined __32BIT__
 extern unsigned int _stklen = 0x2000;
     #endif
@@ -631,6 +678,7 @@ extern "C"
         inst_datetime_defines();
         inst_binary_name(binfname);
         inst_file_name(inpfname, TRUE);
+        inst_cli_defines();
 #endif
         resetglobals();
         sc_ctrlchar = sc_ctrlchar_org;
@@ -703,6 +751,7 @@ extern "C"
     inst_datetime_defines();
     inst_binary_name(binfname);
     inst_file_name(inpfname, TRUE);
+    inst_cli_defines();
 #endif
     resetglobals();
     sc_ctrlchar = sc_ctrlchar_org;
@@ -853,6 +902,7 @@ cleanup:
     delete_dbgstringtable();
 #if !defined NO_DEFINE
     delete_substtable();
+    delete_cli_defines();
 #endif
 #if !defined SC_LIGHT
     delete_docstringtable();
@@ -1301,15 +1351,36 @@ static void parseoptions(
 #endif
         }
         else if ((ptr = strchr(argv[arg], '=')) != NULL) {
+            char* endptr;
             i = ptr - argv[arg];
             if (i > sNAMEMAX) {
                 i = sNAMEMAX;
                 error(200, argv[arg], sNAMEMAX); /* symbol too long, truncated to sNAMEMAX chars */
-            } /* if */
+            }
             strncpy(str, argv[arg], i);
             str[i] = '\0'; /* str holds symbol name */
-            i = atoi(ptr + 1);
-            add_constant(str, i, sGLOBAL, 0);
+            const char* value_str = ptr + 1;
+            if (*value_str == '\0') {
+                /* No value provided (e.g., "DEBUG="), define as 1 by convention */
+                add_constant(str, 1, sGLOBAL, 0);
+            }
+            else {
+                const long value_num = strtol(value_str, &endptr, 10);
+                if (*endptr == '\0' && endptr != value_str) {
+                    /* It's a valid integer */
+                    add_constant(str, (cell)value_num, sGLOBAL, 0);
+                }
+                else {
+                    /* Not a number, treat as a string substitution */
+                    if (strlen(value_str) > sNAMEMAX) {
+                        error(200, value_str, sNAMEMAX); /* symbol too long, truncated to sNAMEMAX chars */
+                    }
+                    else {
+                        /* Store for later substitution */
+                        add_cli_define(str, value_str);
+                    }
+                }
+            }
         }
         else {
             strncpy(str, argv[arg], sizeof(str) - 5); /* -5 because default extension is 4 characters */
@@ -2530,7 +2601,6 @@ static cell initarray(const int ident, const int tag, int dim[], const int numdi
 {
     cell dsize;
     int idx, abortparse;
-    char disable = FALSE;
 
     assert(cur >= 0 && cur < numdim);
     assert(startlit >= 0);
@@ -2569,7 +2639,7 @@ static cell initarray(const int ident, const int tag, int dim[], const int numdi
         if (*errorfound || !matchtoken(',')) {
             abortparse = TRUE;
         }
-        disable = sLiteralQueueDisabled;
+        char disable = sLiteralQueueDisabled;
         sLiteralQueueDisabled = TRUE;
         if (matchtoken('}')) {
             abortparse = TRUE;

--- a/libs/amxxpc32/src/sc3.c
+++ b/libs/amxxpc32/src/sc3.c
@@ -593,16 +593,15 @@ static void plnge2(void (*oper)(void), int (*hier)(value* lval), value* lval1, v
         }
         if (lval2->ident == iCONSTEXPR) { /* constant on right side */
             if (commutative(oper)) {      /* test for commutative operators */
-                value lvaltmp = {0};
-                stgdel(index, cidx); /* scratch pushreg() and constant fetch (then
-                                      * fetch the constant again */
+                stgdel(index, cidx);      /* scratch pushreg() and constant fetch (then
+                                           * fetch the constant again */
                 ldconst(lval2->constval << dbltest(oper, lval1, lval2), sALT);
                 /* now, the primary register has the left operand and the secondary
                  * register the right operand; swap the "lval" variables so that lval1
                  * is associated with the secondary register and lval2 with the
                  * primary register, as is the "normal" case.
                  */
-                lvaltmp = *lval1;
+                const value lvaltmp = *lval1;
                 *lval1 = *lval2;
                 *lval2 = lvaltmp;
             }


### PR DESCRIPTION
# Summary
The compiler command line interface now supports defining both integer constants and preprocessor string macros.
This change allows users to configure builds from the command line without modifying source files.

# Key Features
The command-line argument format `symbol=value` has been extended to intelligently handle different value types:
- **Integer constants**: if value is a number (e.g., `BUILD_ID=451`), it is defined as a constant.
- **String macros**: if value is a string (e.g., `VERSION_NAME="1.2.3 Beta"`), it is defined as a preprocessor substitution, equivalent to an in-source `#define`
- **Flag definitions**: if value is empty (e.g., `DEBUG_MODE=`), the symbol is defined as the constant 1, which is conventional for enabling features in conditional compilation blocks.

# Examples
Here's an example of how you can use the new command-line syntax:
```cmd
amxxpc.exe DEBUG_MODE= BUILD_ID=451 VERSION_NAME="1.2.3 Beta" plugin.sma
```