### PR TITLE
fix: Correct calculation of debug symbol name length

### DIFF
--- a/apps/amxxpc/src/amxxpc.cpp
+++ b/apps/amxxpc/src/amxxpc.cpp
@@ -262,6 +262,7 @@ void ReadFileIntoPl(abl* pl, FILE* fp)
     }
     pl->size = size;
     pl->data = new char[size];
+    memset(pl->data, 0, size);
     rewind(fp);
     fread(pl->data, 1, size, fp);
 }

--- a/libs/amxxpc32/src/sc1.c
+++ b/libs/amxxpc32/src/sc1.c
@@ -1994,6 +1994,10 @@ static void parse(void)
 static void dumplits(void)
 {
     int k = 0;
+
+    if (sc_status == statSKIP) {
+        return;
+    }
     while (k < litidx) {
         /* should be in the data segment */
         assert(curseg == 2);
@@ -2017,11 +2021,14 @@ static void dumplits(void)
 
 /*  dumpzero
  *
- *  Dump zero's for default initial values
+ *  Dump zero's for default initial values of elements of global arrays.
+ *  Elements of local arrays do not need to be dumped, because they are
+ *  allocated on the stack (and the stack is cleared when creating a new
+ *  variable).
  */
 static void dumpzero(int count)
 {
-    if (count <= 0) {
+    if (sc_status == statSKIP || count <= 0) {
         return;
     }
     assert(curseg == 2);

--- a/libs/amxxpc32/src/sc6.c
+++ b/libs/amxxpc32/src/sc6.c
@@ -1063,9 +1063,14 @@ static void append_dbginfo(FILE* fout)
         assert(str[0] != '\0' && str[1] == ':');
         if (str[0] == 'S') {
             dbghdr.symbols++;
-            name = strchr(str + 2, ':');
-            assert(name != NULL);
-            dbghdr.size += sizeof(AMX_DBG_SYMBOL) + strlen(skipwhitespace(name + 1));
+            str = strchr(str + 2, ':');
+            assert(str != NULL);
+            name = skipwhitespace(str + 1);
+            str = strchr(name, ' ');
+            assert(str != NULL);
+            assert((unsigned)(str - name) < sizeof symname);
+            const uint32_t namelen = str ? (str - name) : strlen(name);
+            dbghdr.size += (int32_t)(sizeof(AMX_DBG_SYMBOL) + namelen);
             if ((prevstr = strchr(name, '[')) != NULL) {
                 while ((prevstr = strchr(prevstr + 1, ':')) != NULL) {
                     dbghdr.size += sizeof(AMX_DBG_SYMDIM);


### PR DESCRIPTION
## Summary
Addresses a critical compiler bug causing non-deterministic builds, resulting in `.amxx` files of varying sizes from identical source code.

## Details
The issue was caused by an incorrect calculation of the debug symbol table size, which resulted in incorrect data being written to the executable. This resulted in non-deterministic builds and created a risk of server instability, as `AMXX Mod X` could crash when parsing corrupted debug information.
This patch corrects the calculation logic, ensuring the correct size of the debug symbol table.

## Key Improvements
- Deterministic builds: The compiler now generates identical (byte-for-byte) binaries from the same source code.
- Valid `.amxx` binaries: Eliminates garbage data in the debug section.
- Enhanced stability: Prevents potential server crashes caused by parsing corrupted debug symbols.